### PR TITLE
Feature: Remove double quotes from react-transform-component

### DIFF
--- a/src/components/TransformComponent.js
+++ b/src/components/TransformComponent.js
@@ -21,7 +21,7 @@ function TransformComponent({ children }) {
   }, []);
 
   return (
-    <div ref={wrapperRef} className={`"react-transform-component" ${styles.container}`}>
+    <div ref={wrapperRef} className={`react-transform-component ${styles.container}`}>
       <div ref={contentRef} className={`react-transform-element ${styles.content}`} style={style}>
         {children}
       </div>


### PR DESCRIPTION
This removes double quotes from the class name react-transform-component in the TransformComponent component.

Closes #28