### PR TITLE
move removeEventListeners from componentDidMount to componentWillUnmount

### DIFF
--- a/src/store/StateContext.js
+++ b/src/store/StateContext.js
@@ -63,11 +63,14 @@ class StateProvider extends Component {
     window.addEventListener("mousedown", this.handleStartPanning, passiveOption);
     window.addEventListener("mousemove", this.handlePanning, passiveOption);
     window.addEventListener("mouseup", this.handleStopPanning, passiveOption);
-    return () => {
-      window.removeEventListener("mousedown", this.handleStartPanning, passiveOption);
-      window.removeEventListener("mousemove", this.handlePanning, passiveOption);
-      window.removeEventListener("mouseup", this.handleStopPanning, passiveOption);
-    };
+  }
+
+  componentWillUnmount() {
+    const passiveOption = makePassiveEventOption(false);
+
+    window.removeEventListener("mousedown", this.handleStartPanning, passiveOption);
+    window.removeEventListener("mousemove", this.handlePanning, passiveOption);
+    window.removeEventListener("mouseup", this.handleStopPanning, passiveOption);
   }
 
   componentDidUpdate(oldProps, oldState) {


### PR DESCRIPTION
This PR removes the removeEventListeners from componentDidMount to componentWillUnmount, in order to fix some weird behavior when unmounting the component.

#30 