### PR TITLE
fixed zoom issue on older browsers

### DIFF
--- a/src/components/TransformComponent.tsx
+++ b/src/components/TransformComponent.tsx
@@ -19,6 +19,7 @@ class TransformComponent extends React.Component {
     } = this.context;
 
     const style = {
+      WebkitTransform: `translate(${positionX}px, ${positionY}px) scale(${scale})`,
       transform: `translate(${positionX}px, ${positionY}px) scale(${scale})`,
     };
     return (


### PR DESCRIPTION
Hey,
I have noticed the zoom options are not working in chrome30 browser because transform is not supported in older browser.
so i have added webkitTransform css property for older browser kindly review it and merge it asap.

thanks for the awesome plugin