### PR TITLE
Fix touch Y panning only

### DIFF
--- a/src/store/StateContext.tsx
+++ b/src/store/StateContext.tsx
@@ -264,7 +264,8 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
       this.stateProvider.options.disabled ||
       (event.touches &&
         (event.touches.length !== 1 ||
-          Math.abs(this.startCoords.x - event.touches[0].clientX) < 1)) ||
+          Math.abs(this.startCoords.x - event.touches[0].clientX) < 1 ||
+          Math.abs(this.startCoords.y - event.touches[0].clientY) < 1)) ||
       !wrapperComponent ||
       !contentComponent
     );


### PR DESCRIPTION
Add to checkIsPanningActive to allow for a touch pan in only the Y direction. Currently, touch pans will be cancelled unless they have at least moved 1 pixel in the x direction