### PR TITLE
Add documentation and typings for wrapperClass and contentClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ class Example extends Component {
 | limitToBounds    |  true   |      boolean |
 | limitToWrapper   |  false  |      boolean |
 | centerContent    |  true   |      boolean |
+| contentClass     |         |       string |
+| wrapperClass     |         |       string |
 
 #### scalePadding prop elements
 

--- a/src/store/interfaces/propsInterface.ts
+++ b/src/store/interfaces/propsInterface.ts
@@ -16,6 +16,8 @@ export interface PropsList {
     limitToBounds?: boolean;
     centerContent?: boolean;
     limitToWrapper?: boolean;
+    wrapperClass?: string;
+    contentClass?: string;
   };
   scalePadding?: {
     disabled?: boolean;


### PR DESCRIPTION
Hi,

We tried out both options for the classes and they worked perfectly. Thanks for introducing them. Unfortunately, the options for the class were missing from the documentation and also missing the typings inside the options object. I thought that it would be helpful for the other users of this library to have it added into the documentation as well as in typings.

Can you please publish this new version to npm to help us fix our typing errors.

Best regards
