### PR TITLE
support all selectors in disableOnTarget array

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,22 +158,22 @@ class Example extends Component {
 
 #### Pan prop elements
 
-| Props                 | Default |                                            Type |
-| :-------------------- | :-----: | ----------------------------------------------: |
-| disabled              |  false  |                                         boolean |
-| disableOnTarget       |   []    | array of class names or node tags (div,span...) |
-| lockAxisX             |  false  |                                         boolean |
-| lockAxisY             |  false  |                                         boolean |
-| velocity              |  false  |                                         boolean |
-| velocityEqualToMove   |  false  |                                         boolean |
-| velocitySensitivity   |    1    |                                          number |
-| velocityMinSpeed      |   1.2   |                                          number |
-| velocityBaseTime      |  1800   |                                          number |
-| velocityAnimationType | easeOut |                                          string |
-| padding               |  true   |                                         boolean |
-| paddingSize           |   40    |                                          number |
-| animationTime         |   200   |                                          number |
-| animationType         | easeOut |                                          string |
+| Props                 | Default |               Type |
+| :-------------------- | :-----: | ------------------ |
+| disabled              |  false  |            boolean |
+| disableOnTarget       |   []    | array of selectors |
+| lockAxisX             |  false  |            boolean |
+| lockAxisY             |  false  |            boolean |
+| velocity              |  false  |            boolean |
+| velocityEqualToMove   |  false  |            boolean |
+| velocitySensitivity   |    1    |             number |
+| velocityMinSpeed      |   1.2   |             number |
+| velocityBaseTime      |  1800   |             number |
+| velocityAnimationType | easeOut |             string |
+| padding               |  true   |            boolean |
+| paddingSize           |   40    |             number |
+| animationTime         |   200   |             number |
+| animationType         | easeOut |             string |
 
 #### Pinch prop elements
 

--- a/src/store/StateContext.tsx
+++ b/src/store/StateContext.tsx
@@ -248,14 +248,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
       pan: { disableOnTarget },
     } = this.stateProvider;
 
-    return (
-      disableOnTarget
-        .map(tag => tag.toUpperCase())
-        .includes(event.target.tagName) ||
-      disableOnTarget.find(element =>
-        event.target.classList.value.includes(element),
-      )
-    );
+    return disableOnTarget.some((selector) => event.target.matches(selector));
   };
 
   checkIsPanningActive = event => {


### PR DESCRIPTION
This is a small update that makes the `disableOnTarget` Pan prop much more versatile, using the [Element.matches()](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches) API instead of manual parsing.