### PR TITLE
Fix disableOnTarget classList usage

### DIFF
--- a/src/store/StateContext.tsx
+++ b/src/store/StateContext.tsx
@@ -253,7 +253,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
         .map(tag => tag.toUpperCase())
         .includes(event.target.tagName) ||
       disableOnTarget.find(element =>
-        event.target.classList.value.includes(element),
+        event.target.classList.contains(element),
       )
     );
   };


### PR DESCRIPTION
Instead of classList.value.includes(), we should use classList.contains() which is supported in IE.
https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/contains