### PR TITLE
Types improvement in TransformWrapper children function and callback props

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ class Example extends Component {
 
 | Value                                                                   | Description                                    |      Type      |
 | :---------------------------------------------------------------------- | :--------------------------------------------- | :------------: |
+| scale                                                                   | Current scale value                            |     Number     |
+| positionX                                                               | Current position x                             |     Number     |
+| positionY                                                               | Current position y                             |     Number     |
+| previousScale                                                           | Previous scale value                           |     Number     |
 | setScale(scale, animationTime, animationType)                           | Sets scale                                     |     Number     |
 | setPositionX(positionX, animationTime, animationType)                   | Sets position x                                |     Number     |
 | setPositionY(positionY, animationTime, animationType)                   | Sets position y                                |     Number     |

--- a/src/store/StateContext.tsx
+++ b/src/store/StateContext.tsx
@@ -30,9 +30,7 @@ import {
   StateContextProps,
 } from "./interfaces/stateContextInterface";
 import { getValidPropsFromObject } from "./propsHandlers";
-import { availableAnimations } from "./animations/utils";
-
-type AvailableAnimations = keyof typeof availableAnimations
+import { AnimationType } from "./interfaces/animationType";
 
 const Context = React.createContext({});
 
@@ -466,7 +464,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     handleDoubleClick.call(this, event, 1, step);
   };
 
-  setScale = (newScale, speed = 200, type: AvailableAnimations = "easeOut") => {
+  setScale = (newScale, speed = 200, type: AnimationType = "easeOut") => {
     const {
       positionX,
       positionY,
@@ -488,7 +486,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     });
   };
 
-  setPositionX = (newPosX, speed = 200, type: AvailableAnimations = "easeOut") => {
+  setPositionX = (newPosX, speed = 200, type: AnimationType = "easeOut") => {
     const {
       positionX,
       positionY,
@@ -511,7 +509,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     });
   };
 
-  setPositionY = (newPosY, speed = 200, type: AvailableAnimations = "easeOut") => {
+  setPositionY = (newPosY, speed = 200, type: AnimationType = "easeOut") => {
     const {
       positionX,
       scale,
@@ -540,7 +538,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     newPosY,
     newScale,
     speed = 200,
-    type: AvailableAnimations = "easeOut",
+    type: AnimationType = "easeOut",
   ) => {
     const {
       positionX,

--- a/src/store/StateContext.tsx
+++ b/src/store/StateContext.tsx
@@ -464,7 +464,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     handleDoubleClick.call(this, event, 1, step);
   };
 
-  setScale = (newScale, speed = 200, type: AnimationType = "easeOut") => {
+  setScale = (newScale: number, speed = 200, type: AnimationType = "easeOut") => {
     const {
       positionX,
       positionY,
@@ -486,7 +486,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     });
   };
 
-  setPositionX = (newPosX, speed = 200, type: AnimationType = "easeOut") => {
+  setPositionX = (newPosX: number, speed = 200, type: AnimationType = "easeOut") => {
     const {
       positionX,
       positionY,
@@ -509,7 +509,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     });
   };
 
-  setPositionY = (newPosY, speed = 200, type: AnimationType = "easeOut") => {
+  setPositionY = (newPosY: number, speed = 200, type: AnimationType = "easeOut") => {
     const {
       positionX,
       scale,
@@ -534,9 +534,9 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
   };
 
   setTransform = (
-    newPosX,
-    newPosY,
-    newScale,
+    newPosX: number,
+    newPosY: number,
+    newScale: number,
     speed = 200,
     type: AnimationType = "easeOut",
   ) => {

--- a/src/store/StateContext.tsx
+++ b/src/store/StateContext.tsx
@@ -30,6 +30,9 @@ import {
   StateContextProps,
 } from "./interfaces/stateContextInterface";
 import { getValidPropsFromObject } from "./propsHandlers";
+import { availableAnimations } from "./animations/utils";
+
+type AvailableAnimations = keyof typeof availableAnimations
 
 const Context = React.createContext({});
 
@@ -463,7 +466,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     handleDoubleClick.call(this, event, 1, step);
   };
 
-  setScale = (newScale, speed = 200, type = "easeOut") => {
+  setScale = (newScale, speed = 200, type: AvailableAnimations = "easeOut") => {
     const {
       positionX,
       positionY,
@@ -485,7 +488,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     });
   };
 
-  setPositionX = (newPosX, speed = 200, type = "easeOut") => {
+  setPositionX = (newPosX, speed = 200, type: AvailableAnimations = "easeOut") => {
     const {
       positionX,
       positionY,
@@ -508,7 +511,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     });
   };
 
-  setPositionY = (newPosY, speed = 200, type = "easeOut") => {
+  setPositionY = (newPosY, speed = 200, type: AvailableAnimations = "easeOut") => {
     const {
       positionX,
       scale,
@@ -537,7 +540,7 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
     newPosY,
     newScale,
     speed = 200,
-    type = "easeOut",
+    type: AvailableAnimations = "easeOut",
   ) => {
     const {
       positionX,

--- a/src/store/interfaces/animationType.ts
+++ b/src/store/interfaces/animationType.ts
@@ -1,0 +1,3 @@
+import { availableAnimations } from '../animations/utils';
+
+export type AnimationType = keyof typeof availableAnimations

--- a/src/store/interfaces/propsInterface.ts
+++ b/src/store/interfaces/propsInterface.ts
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { StateProvider } from '../StateContext';
+import { AnimationType } from './animationType';
 
 export interface TransformWrapperCallbackProps {
   scale: number;
@@ -39,7 +40,7 @@ export interface PropsList {
     disabled?: boolean;
     size?: number;
     animationTime?: number;
-    animationType?: string;
+    animationType?: AnimationType;
   };
   wheel?: {
     disabled?: boolean;
@@ -51,7 +52,7 @@ export interface PropsList {
   pan?: {
     disabled?: boolean;
     velocity?: boolean;
-    panAnimationType?: string;
+    panAnimationType?: AnimationType;
     velocityEqualToMove?: boolean;
     velocitySensitivity?: number;
     velocityActiveScale?: number;
@@ -62,7 +63,7 @@ export interface PropsList {
     padding?: boolean;
     paddingSize?: number;
     animationTime?: number;
-    animationType?: string;
+    animationType?: AnimationType;
   };
   pinch?: {
     disabled?: boolean;
@@ -73,14 +74,14 @@ export interface PropsList {
     step?: number;
     animation?: boolean;
     animationTime?: number;
-    animationType?: string;
+    animationType?: AnimationType;
   };
   zoomOut?: {
     disabled?: boolean;
     step?: number;
     animation?: boolean;
     animationTime?: number;
-    animationType?: string;
+    animationType?: AnimationType;
   };
   doubleClick?: {
     disabled?: boolean;
@@ -88,14 +89,14 @@ export interface PropsList {
     mode?: string;
     animation?: boolean;
     animationTime?: number;
-    animationType?: string;
+    animationType?: AnimationType;
   };
   reset?: {
     disabled?: boolean;
     step?: number;
     animation?: boolean;
     animationTime?: number;
-    animationType?: string;
+    animationType?: AnimationType;
   };
   children?: ReactNode | ((childrenFunctionProps: TransformWrapperChildrenFunctionProps) => ReactNode);
   defaultPositionX?: number;

--- a/src/store/interfaces/propsInterface.ts
+++ b/src/store/interfaces/propsInterface.ts
@@ -1,11 +1,14 @@
 import { ReactNode } from 'react';
 import { StateProvider } from '../StateContext';
 
-export interface TransformWrapperChildrenFunctionProps {
+export interface TransformWrapperCallbackProps {
   scale: number;
   positionX: number;
   positionY: number;
   previousScale: number;
+};
+
+export interface TransformWrapperChildrenFunctionProps extends TransformWrapperCallbackProps {
   setScale: typeof StateProvider.prototype.setPositionX;
   setPositionX: typeof StateProvider.prototype.setPositionX;
   setPositionY: typeof StateProvider.prototype.setPositionY;
@@ -98,14 +101,14 @@ export interface PropsList {
   defaultPositionX?: number;
   defaultPositionY?: number;
   defaultScale?: number;
-  onWheelStart?: any;
-  onWheel?: any;
-  onWheelStop?: any;
-  onPanningStart?: any;
-  onPanning?: any;
-  onPanningStop?: any;
-  onPinchingStart?: any;
-  onPinching?: any;
-  onPinchingStop?: any;
-  onZoomChange?: any;
+  onWheelStart?: (props: TransformWrapperCallbackProps) => void;
+  onWheel?: (props: TransformWrapperCallbackProps) => void;
+  onWheelStop?: (props: TransformWrapperCallbackProps) => void;
+  onPanningStart?: (props: TransformWrapperCallbackProps) => void;
+  onPanning?: (props: TransformWrapperCallbackProps) => void;
+  onPanningStop?: (props: TransformWrapperCallbackProps) => void;
+  onPinchingStart?: (props: TransformWrapperCallbackProps) => void;
+  onPinching?: (props: TransformWrapperCallbackProps) => void;
+  onPinchingStop?: (props: TransformWrapperCallbackProps) => void;
+  onZoomChange?: (props: TransformWrapperCallbackProps) => void;
 }

--- a/src/store/interfaces/propsInterface.ts
+++ b/src/store/interfaces/propsInterface.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { StateProvider } from '../StateContext';
 
-export type TransformWrapperChildrenFunctionProps = {
+export interface TransformWrapperChildrenFunctionProps {
   scale: number;
   positionX: number;
   positionY: number;

--- a/src/store/interfaces/propsInterface.ts
+++ b/src/store/interfaces/propsInterface.ts
@@ -1,4 +1,19 @@
-import { ReactNode } from "react";
+import { ReactNode } from 'react';
+import { StateProvider } from '../StateContext';
+
+export type TransformWrapperChildrenFunctionProps = {
+  scale: number;
+  positionX: number;
+  positionY: number;
+  previousScale: number;
+  setScale: typeof StateProvider.prototype.setPositionX;
+  setPositionX: typeof StateProvider.prototype.setPositionX;
+  setPositionY: typeof StateProvider.prototype.setPositionY;
+  zoomIn: typeof StateProvider.prototype.zoomIn;
+  zoomOut: typeof StateProvider.prototype.zoomOut;
+  setTransform: typeof StateProvider.prototype.setTransform;
+  resetTransform: typeof StateProvider.prototype.resetTransform;
+};
 
 export interface PropsList {
   scale?: number;
@@ -79,7 +94,7 @@ export interface PropsList {
     animationTime?: number;
     animationType?: string;
   };
-  children?: ReactNode;
+  children?: ReactNode | ((childrenFunctionProps: TransformWrapperChildrenFunctionProps) => ReactNode);
   defaultPositionX?: number;
   defaultPositionY?: number;
   defaultScale?: number;

--- a/src/store/interfaces/propsInterface.ts
+++ b/src/store/interfaces/propsInterface.ts
@@ -10,7 +10,7 @@ export interface TransformWrapperCallbackProps {
 };
 
 export interface TransformWrapperChildrenFunctionProps extends TransformWrapperCallbackProps {
-  setScale: typeof StateProvider.prototype.setPositionX;
+  setScale: typeof StateProvider.prototype.setScale;
   setPositionX: typeof StateProvider.prototype.setPositionX;
   setPositionY: typeof StateProvider.prototype.setPositionY;
   zoomIn: typeof StateProvider.prototype.zoomIn;


### PR DESCRIPTION
@prc5 In issue #148, you mentioned that you want to
> Implement full typescript support

So, I tried to add typings that were missing which will be useful for the end-user. Here is PR for the same.

In the PR, I added ts typings for values returned from TransformWrapper component (`TransformWrapperChildrenFunctionProps` eg. `setScale`, `setPositionX` etc.), callback methods of TransformWrapper component (`TransformWrapperCallbackProps` eg. `onPinching`, `onPanning` etc.) and `AnimationType` type.

1. For `TransformWrapperChildrenFunctionProps`:-
for methods returned by TransformWrapper, instead of manually creating type, I used the following approach so that types will be automatically generated and will always be synced with code changes.
```
  setScale: typeof StateProvider.prototype.setPositionX;
  setPositionX: typeof StateProvider.prototype.setPositionX;
  setPositionY: typeof StateProvider.prototype.setPositionY;
  zoomIn: typeof StateProvider.prototype.zoomIn;
  zoomOut: typeof StateProvider.prototype.zoomOut;
  setTransform: typeof StateProvider.prototype.setTransform;
  resetTransform: typeof StateProvider.prototype.resetTransform;
```

2. I created the following type manually and used it in both `TransformWrapperChildrenFunctionProps` and `TransformWrapperCallbackProps`. They were manually created because I could not find any way to dynamically generate them using StateProvider
```
export type TransformWrapperCallbackProps = {
  scale: number;
  positionX: number;
  positionY: number;
  previousScale: number;
};
```

3. I generated `AnimationType` type from `availableAnimations` array in `utils` and used it in `propsInterface` and in functions like `setTransform`  and `resetTransform` so that auto completion will work for animation name
```
import { availableAnimations } from '../animations/utils';
export type AnimationType = keyof typeof availableAnimations
```

I noticed that options are also passed to callback functions and render prop. But I intentionally skipped them because they are of no much use. I also added new types in README.

### End Result:-
![PR1](https://user-images.githubusercontent.com/25122531/98449468-e6a04080-2159-11eb-8ab4-4353bf218f63.png)
![PR2](https://user-images.githubusercontent.com/25122531/98449475-f455c600-2159-11eb-9c3a-ef48d5aa7fe3.png)
![PR3](https://user-images.githubusercontent.com/25122531/98449641-1ef44e80-215b-11eb-9725-1d68f7267ebf.png)
