### PR TITLE
Add pan.enableEventPropagation property

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,22 +158,23 @@ class Example extends Component {
 
 #### Pan prop elements
 
-| Props                 | Default |                                            Type |
-| :-------------------- | :-----: | ----------------------------------------------: |
-| disabled              |  false  |                                         boolean |
-| disableOnTarget       |   []    | array of class names or node tags (div,span...) |
-| lockAxisX             |  false  |                                         boolean |
-| lockAxisY             |  false  |                                         boolean |
-| velocity              |  false  |                                         boolean |
-| velocityEqualToMove   |  false  |                                         boolean |
-| velocitySensitivity   |    1    |                                          number |
-| velocityMinSpeed      |   1.2   |                                          number |
-| velocityBaseTime      |  1800   |                                          number |
-| velocityAnimationType | easeOut |                                          string |
-| padding               |  true   |                                         boolean |
-| paddingSize           |   40    |                                          number |
-| animationTime         |   200   |                                          number |
-| animationType         | easeOut |                                          string |
+| Props                  | Default |                                            Type |
+| :--------------------  | :-----: | ----------------------------------------------: |
+| disabled               |  false  |                                         boolean |
+| disableOnTarget        |   []    | array of class names or node tags (div,span...) |
+| lockAxisX              |  false  |                                         boolean |
+| lockAxisY              |  false  |                                         boolean |
+| velocity               |  false  |                                         boolean |
+| velocityEqualToMove    |  false  |                                         boolean |
+| velocitySensitivity    |    1    |                                          number |
+| velocityMinSpeed       |   1.2   |                                          number |
+| velocityBaseTime       |  1800   |                                          number |
+| velocityAnimationType  | easeOut |                                          string |
+| padding                |  true   |                                         boolean |
+| paddingSize            |   40    |                                          number |
+| animationTime          |   200   |                                          number |
+| animationType          | easeOut |                                          string |
+| enableEventPropagation |  false  |                                         boolean |
 
 #### Pinch prop elements
 

--- a/src/store/InitialState.ts
+++ b/src/store/InitialState.ts
@@ -44,6 +44,7 @@ export const initialState = {
     panReturnAnimationTime: 400,
     panReturnAnimationType: "easeOut",
     disableOnTarget: [],
+    enableEventPropagation: false,
   },
   pinch: {
     disabled: false,

--- a/src/store/StateContext.tsx
+++ b/src/store/StateContext.tsx
@@ -320,7 +320,15 @@ class StateProvider extends Component<StateContextProps, StateContextState> {
   handlePanning = event => {
     if (this.isDown) event.preventDefault();
     if (this.checkIsPanningActive(event)) return;
-    event.stopPropagation();
+
+    const {
+      pan: { 
+        enableEventPropagation 
+      },
+    } = this.stateProvider;
+    if (!enableEventPropagation) {
+      event.stopPropagation();
+    }
     calculateVelocityStart.call(this, event);
     handlePanning.call(this, event);
     handleCallback(this.props.onPanning, this.getCallbackProps());

--- a/src/store/interfaces/propsInterface.ts
+++ b/src/store/interfaces/propsInterface.ts
@@ -45,6 +45,7 @@ export interface PropsList {
     paddingSize?: number;
     animationTime?: number;
     animationType?: string;
+    enableEventPropagation?: boolean;
   };
   pinch?: {
     disabled?: boolean;


### PR DESCRIPTION
Sometimes it is needed to propagate the ontouchmove event, because there might be other children components also listening to the ontouchmove event

Issue: https://github.com/prc5/react-zoom-pan-pinch/issues/177