### PR TITLE
fix: add mozilla prefixes to fix truncation on firefox

### DIFF
--- a/example/src/index.css
+++ b/example/src/index.css
@@ -7,6 +7,7 @@ body {
 }
 
 .element {
+  width: -moz-fit-content;
   width: fit-content;
   background: rgba(100, 100, 100, 0.25);
   width: 100%;

--- a/src/components/TransformComponent.module.css
+++ b/src/components/TransformComponent.module.css
@@ -1,5 +1,7 @@
 .container {
   position: relative;
+  width: -moz-fit-content;
+  height: -moz-fit-content;
   width: fit-content;
   height: fit-content;
   overflow: hidden;
@@ -15,6 +17,8 @@
 .content {
   display: flex;
   flex-wrap: wrap;
+  width: -moz-fit-content;
+  height: -moz-fit-content;
   width: fit-content;
   height: fit-content;
   margin: 0;


### PR DESCRIPTION
Firefox doesn't support unprefixed fit-content, and this was causing large images to be truncated depending on the size of the image and container. The other option would be to use something like autoprefixer to do this, but I noticed you have manual prefixes for other properties, so I followed that style here.

[Caniuse reference](https://caniuse.com/?search=fit-content)