### PR TITLE
bumping react and react-dom versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
This version of the library works perfectly with React 17. Since the peer dependencies accepts only 15/16, it throws warnings in the projects with React 17.