### PR TITLE
Fix filename for jsnext:main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
-  "jsnext:main": "dist/index.es.js",
+  "jsnext:main": "dist/index.esm.js",
   "engines": {
     "node": ">=8",
     "npm": ">=5"


### PR DESCRIPTION
Hi, thanks for the great library!

This issue was found by eslint in an application. The application compiled fine, but eslint errored with
```
1:54  error  Unable to resolve path to module 'react-zoom-pan-pinch'  import/no-unresolved
```
This was due to eslint trying to resolve the `jsnext:main` value in `package.json`, which this PR fixes.