### PR TITLE
Include -moz-fit-content in wrapper and content classes

### DIFF
--- a/src/components/transform-component.module.css
+++ b/src/components/transform-component.module.css
@@ -1,6 +1,8 @@
 .wrapper {
   position: relative;
+  width: -moz-fit-content;
   width: fit-content;
+  height: -moz-fit-content;
   height: fit-content;
   overflow: hidden;
   -webkit-touch-callout: none; /* iOS Safari */
@@ -15,7 +17,9 @@
 .content {
   display: flex;
   flex-wrap: wrap;
+  width: -moz-fit-content;
   width: fit-content;
+  height: -moz-fit-content;
   height: fit-content;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
- Small bugfix resolving the TransformComponent rendering on the LHS of the TransformWrapper when the centerOnInit prop is true (Vertical centering is working as expected).
- I may be mistaken but webpack and/or storybook is generating these styles automatically but rollup isn't hence why the issue doesn't show up in storybook.

- Note: If you are experiencing this issue and need an immediate fix add `width & height: -moz-fit-content;` to a style/class passed to TransformWrapper and TransformComponent.