### PR TITLE
Switch from react-jsx to react to avoid import errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es5",
     "sourceMap": true,
     "allowJs": false,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "declaration": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This resolves the issue with `Module not found: Can't resolve 'react/jsx-runtime' in '/node_modules/react-zoom-pan-pinch/dist'`

The "react-jsx" option inserts `import { jsx } from 'react/jsx-runtime';` into dist/index.esm.js which causes the import error.
Using the "react" option uses React.createElement instead, which already exists.

Fixes #218
