### PR TITLE
Publish src folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "webpack-cli": "^4.6.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This adds "src" to the set of published files, which allows source mapped URLs to resolve for consumers of this package. Resolves #265.

If the download size of the package is what we want to optimize for, an alternative approach would be to remove source map URL comments from the production build of this package.
