### PR TITLE
fix zoomToNode if page has scrolled

### DIFF
--- a/src/core/handlers/handlers.utils.ts
+++ b/src/core/handlers/handlers.utils.ts
@@ -180,8 +180,8 @@ function getOffset(element: HTMLElement): PositionType {
   }
 
   return {
-    x: offsetLeft,
-    y: offsetTop,
+    x: offsetLeft - window.scrollX,
+    y: offsetTop - window.scrollY,
   };
 }
 


### PR DESCRIPTION
subtract window scroll position from offsets in getOffset()