### PR TITLE
Add fix for scaling issue with SVG's on Safari

### DIFF
--- a/src/utils/styles.utils.ts
+++ b/src/utils/styles.utils.ts
@@ -5,7 +5,7 @@ export const getTransformStyles = (
   y: number,
   scale: number,
 ): string => {
-  return `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  return `matrix(${scale}, 0,0, ${scale}, ${x}, ${y})`;
 };
 
 export const getCenterPosition = (


### PR DESCRIPTION
On Safari ( both Desktop and iOS ) there is a [bug with Webkit](https://bugs.webkit.org/show_bug.cgi?id=27684) around scaling images / SVGs that makes them pixelated. By using `transform: matrix()` instead of `transform: translate3d() scale()` this removes the issue and is compatible with that was being archived with the scale and translate.