### PR TITLE
Use translate instead of translate3d

### DIFF
--- a/src/utils/styles.utils.ts
+++ b/src/utils/styles.utils.ts
@@ -5,7 +5,7 @@ export const getTransformStyles = (
   y: number,
   scale: number,
 ): string => {
-  return `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  return `translate(${x}px, ${y}px) scale(${scale})`;
 };
 
 export const getCenterPosition = (


### PR DESCRIPTION
Use translate 2d instead of 3d to prevent SVG bluring on Safari