### PR TITLE
Update README.md to fix error in code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ const Control = ({zoomIn, zoomOut, resetTransform}:any)=>(
         ref={transformComponentRef}
       >
         {(utils) => (
-          <>
+          </React.Fragment>
             <Control {...utils}/>
             <TransformComponent>
               <img src="image.jpg" alt="test" id="imgExample" />


### PR DESCRIPTION
<> and <React.Fragment> were used inconsistently, the component started with <> but was closed with </React.Fragment> i have replaced <> by  <React.Fragment> which is also consistent with other examples.