### PR TITLE
Fix source map not found on source-map-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,8 +95,7 @@
     "webpack-cli": "^5.0.1"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "engines": {
     "node": ">=8",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "commitlint": "^17.0.2",
     "cross-env": "^7.0.3",
     "eslint": "^8.17.0",
-    "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-next": "12.1.6",
     "eslint-config-prettier": "^8.5.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ export default [
         exclude: "node_modules/**",
       }),
       del({ targets: ["dist/*"] }),
-      typescript(),
+      typescript({ sourceMap: false }),
       postcss({
         modules: true,
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7532,15 +7532,6 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-airbnb-base@^14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz#8a2eb38455dc5a312550193b319cdaeef042cd1e"
-  integrity sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
-  dependencies:
-    confusing-browser-globals "^1.0.10"
-    object.assign "^4.1.2"
-    object.entries "^1.1.2"
-
 eslint-config-airbnb-base@^15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz#6b09add90ac79c2f8d723a2580e07f3925afd236"
@@ -7558,14 +7549,14 @@ eslint-config-airbnb-typescript@^17.0.0:
   dependencies:
     eslint-config-airbnb-base "^15.0.0"
 
-eslint-config-airbnb@^18.2.1:
-  version "18.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz#b7fe2b42f9f8173e825b73c8014b592e449c98d9"
-  integrity sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==
+eslint-config-airbnb@^19.0.4:
+  version "19.0.4"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz#84d4c3490ad70a0ffa571138ebcdea6ab085fdc3"
+  integrity sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==
   dependencies:
-    eslint-config-airbnb-base "^14.2.1"
+    eslint-config-airbnb-base "^15.0.0"
     object.assign "^4.1.2"
-    object.entries "^1.1.2"
+    object.entries "^1.1.5"
 
 eslint-config-next@12.1.6:
   version "12.1.6"
@@ -12413,7 +12404,7 @@ object.assign@^4.1.2, object.assign@^4.1.3, object.assign@^4.1.4:
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
-object.entries@^1.1.0, object.entries@^1.1.2, object.entries@^1.1.5, object.entries@^1.1.6:
+object.entries@^1.1.0, object.entries@^1.1.5, object.entries@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.6.tgz#9737d0e5b8291edd340a3e3264bb8a3b00d5fa23"
   integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==


### PR DESCRIPTION
I found an issue like this thread. https://github.com/prc5/react-zoom-pan-pinch/issues/356

**What is included in this PR?**
- Package updated for fixing peer dependency conflict. I found this when I debug this package by running `npm pack`.
- Disable source map handler from TypeScript plugin and let Rollup managed it. Ref: https://stackoverflow.com/a/63235210

**How to test?**
- Check out this branch.
- Run `yarn & yarn build`.
- Run `npm pack`. You will get a file at the root of the project called `react-zoom-pan-pinch-0.0.0.tgz`.
- Go to the target project that uses this library and edit `package.json` to add `"react-zoom-pan-pinch": "file:../react-zoom-pan-pinch/react-zoom-pan-pinch-0.0.0.tgz",` as dependency. 
- Test it whatever.

**Proof.**
I can debug on typescript code like this. We don't need `src` directory in package because we had `.d.ts` files in `dist/src` already.

![image](https://user-images.githubusercontent.com/1168777/227519596-75c26b75-72c1-4d06-a298-8b63d28285cf.png)
