### PR TITLE
Fix scale calculation

### DIFF
--- a/src/core/handlers/handlers.utils.ts
+++ b/src/core/handlers/handlers.utils.ts
@@ -24,7 +24,7 @@ export const handleCalculateButtonZoom = (
     throw new Error("Wrapper is not mounted");
   }
 
-  const targetScale = scale * Math.exp(delta * step);
+  const targetScale = scale + delta * step;
 
   const newScale = checkZoomBounds(
     roundNumber(targetScale, 3),

--- a/src/core/wheel/wheel.utils.ts
+++ b/src/core/wheel/wheel.utils.ts
@@ -86,7 +86,7 @@ export const handleCalculateWheelZoom = (
     throw new Error("Wrapper is not mounted");
   }
 
-  const targetScale = scale + delta * (scale - scale * step) * step;
+  const targetScale = scale + delta * step;
 
   if (getTarget) return targetScale;
   const paddingEnabled = disable ? false : !disabled;


### PR DESCRIPTION
#275 Points out an issue where the scale calculation is inaccurate based on the provided step sensitivity.

For instance, if the current scale is 1, and the step sensitivity is 0.5, zooming will result in the scale going from 1 -> 1.65 -> 2.72.

With the proposed change, zooming will produce a scale going from 1 -> 1.5 -> 2.