### PR TITLE
fix: 🐛 ignore TS 5.0 deprecations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
+    "ignoreDeprecations": "5.0",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
TS 5.5 will depreceate "suppressImplicitAnyIndexErrors", which means errors are being thrown in projects using more up-to-date TS versions. This fix simply ingores 5.0 deprecation errors as the TS docs suggest.