### PR TITLE
Add smooth and smooth step options to wheel

### DIFF
--- a/src/constants/state.constants.ts
+++ b/src/constants/state.constants.ts
@@ -21,6 +21,8 @@ export const initialSetup: LibrarySetup = {
   disablePadding: false,
   wheel: {
     step: 0.2,
+    smooth: false,
+    smoothStep: 0.001,
     disabled: false,
     wheelDisabled: false,
     touchPadDisabled: false,

--- a/src/core/wheel/wheel.logic.ts
+++ b/src/core/wheel/wheel.logic.ts
@@ -46,7 +46,7 @@ export const handleWheelZoom = (
     disablePadding,
   } = setup;
   const { size, disabled } = zoomAnimation;
-  const { step } = wheel;
+  const { step, smooth, smoothStep } = wheel;
 
   if (!contentComponent) {
     throw new Error("Component not mounted");
@@ -56,10 +56,11 @@ export const handleWheelZoom = (
   event.stopPropagation();
 
   const delta = getDelta(event, null);
+  const zoomStep = smooth ? smoothStep * Math.abs(event.deltaY) : step;
   const newScale = handleCalculateWheelZoom(
     contextInstance,
     delta,
-    step,
+    zoomStep,
     !event.ctrlKey,
   );
 

--- a/src/models/context.model.ts
+++ b/src/models/context.model.ts
@@ -68,6 +68,8 @@ export type ReactZoomPanPinchProps = {
   customTransform?: (x: number, y: number, scale: number) => string;
   wheel?: {
     step?: number;
+    smoothStep?: number;
+    smooth?: boolean;
     disabled?: boolean;
     wheelDisabled?: boolean;
     touchPadDisabled?: boolean;

--- a/src/stories/docs/props.tsx
+++ b/src/stories/docs/props.tsx
@@ -176,6 +176,18 @@ export const wrapperPropsTable: ComponentProps = {
       defaultValue: String(initialSetup.wheel.step),
       description: "The sensitivity of zooming with the wheel/touchpad.",
     },
+    smoothStep: {
+      type: ["number"],
+      defaultValue: String(initialSetup.wheel.smoothStep),
+      description:
+        "The sensitivity multiplier of zooming with the wheel/touchpad used, instead of the step value, when smooth scrolling is enabled.",
+    },
+    smooth: {
+      type: ["boolean"],
+      defaultValue: String(initialSetup.wheel.smooth),
+      description:
+        "Enable smooth scrolling by multiplying the scroll delta with the smooth step factor.",
+    },
     disabled: {
       type: ["boolean"],
       defaultValue: String(initialSetup.wheel.disabled),

--- a/src/stories/types/args.types.ts
+++ b/src/stories/types/args.types.ts
@@ -16,6 +16,24 @@ export const argsTypes = {
       defaultValue: { summary: "0" },
     },
   },
+  "wheel.smoothStep": {
+    defaultValue: initialSetup.wheel.smoothStep,
+    control: {
+      type: "number",
+      min: 0,
+    },
+    table: {
+      defaultValue: { summary: "0" },
+    },
+  },
+  "wheel.smooth": {
+    defaultValue: initialSetup.wheel.smooth,
+    control: { type: "boolean" },
+    table: {
+      defaultValue: { summary: "false" },
+      type: { summary: "boolean" },
+    },
+  },
   "wheel.disabled": {
     defaultValue: initialSetup.wheel.disabled,
     control: { type: "boolean" },


### PR DESCRIPTION
This adds two options smooth and smoothStep to the wheel settings.

The reason for this is that scrolling on trackpads has a tiny delta compared to mouse wheels and therefore jumps a lot using the same step value as a mouse wheel. If you're not using trackpads this might be ok, if you're looking for a smoother scroll on either input this is not the desired behavior.
I ran into this issue on a windows laptop (Microsoft Surface Laptop 3) and it has also been reported in https://github.com/prc5/react-zoom-pan-pinch/issues/123 on mac.

To me smooth step props were the best way to implement this change as that would not be specific to the original issue.
As far as I know there's no definitive way of figuring out if you're using a trackpad or not so a separate trackpadStep isn't an option.
Please let me know if there's a way more in line with what you want for the project (great work btw), I just needed the fix for mine :)