### PR TITLE
docs: ✏️ Fix storybook props

### DIFF
--- a/src/stories/docs/props.tsx
+++ b/src/stories/docs/props.tsx
@@ -225,16 +225,16 @@ export const wrapperPropsTable: ComponentProps = {
         "Disable the panning velocity feature. It's triggered when you release the mouse button so the content is still moving after it and slowing down with calculated time.",
     },
     lockAxisX: {
-      type: ["string[]"],
-      defaultValue: String(initialSetup.panning.activationKeys),
+      type: ["boolean"],
+      defaultValue: String(initialSetup.panning.lockAxisX),
       description:
-        "List of keys which, when held down, should activate this feature.",
+        "Disable the panning feature for the X axis (prevents horizontal panning).",
     },
     lockAxisY: {
-      type: ["string[]"],
-      defaultValue: String(initialSetup.panning.activationKeys),
+      type: ["boolean"],
+      defaultValue: String(initialSetup.panning.lockAxisY),
       description:
-        "List of keys which, when held down, should activate this feature.",
+        "Disable the panning feature for the Y axis (prevents vertical panning).",
     },
     activationKeys: {
       type: ["string[]"],
@@ -326,7 +326,7 @@ export const wrapperPropsTable: ComponentProps = {
     },
     size: {
       type: ["number"],
-      defaultValue: String(initialSetup.zoomAnimation.disabled),
+      defaultValue: String(initialSetup.zoomAnimation.size),
       description:
         "Thanks to size, we can control the zoom out values larger than that controlled by the value of another 'minScale' prop. This results in an animated return of the value to the minimum scale when the zooming has finished. This works for both touchpad zooming and pinching.",
     },


### PR DESCRIPTION
Fixes #365: `zoomAnimation.size` default value was previously a boolean instead of a number:

![image](https://github.com/prc5/react-zoom-pan-pinch/assets/57621865/455b7852-be11-419e-b6b9-ff93c77b59b6)

Changed to use correct value `state.constants.ts`:
![image](https://github.com/prc5/react-zoom-pan-pinch/assets/57621865/19423022-0f54-429d-87b8-843b41a30f79)

---

Also fixes `panning.lockAxisX` and `panning.lockAxisY`, which were previously a copy paste error from `panning.activationKeys`:
![image](https://github.com/prc5/react-zoom-pan-pinch/assets/57621865/9bc3394b-95d2-4f38-9fea-fa9dbf3ed8b4)

Changed to use correct values from `state.constants.ts`, and updated description:
![image](https://github.com/prc5/react-zoom-pan-pinch/assets/57621865/989cb305-daac-4662-9322-fae084641e33)


