### PR TITLE
fix touchmove event cancelable warning

### DIFF
--- a/src/core/instance.core.ts
+++ b/src/core/instance.core.ts
@@ -259,7 +259,9 @@ export class ZoomPanPinch {
       return;
     }
 
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
     event.stopPropagation();
 
     const { positionX, positionY } = this.transformState;
@@ -298,7 +300,9 @@ export class ZoomPanPinch {
     if (event.button === 1 && !this.setup.panning.allowMiddleClickPan) return;
     if (event.button === 2 && !this.setup.panning.allowRightClickPan) return;
 
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
     event.stopPropagation();
 
     handleCancelAnimation(this);
@@ -318,7 +322,9 @@ export class ZoomPanPinch {
     const keysPressed = this.isPressingKeys(this.setup.panning.activationKeys);
     if (!keysPressed) return;
 
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
     event.stopPropagation();
 
     handlePanning(this, event.clientX, event.clientY);
@@ -362,7 +368,9 @@ export class ZoomPanPinch {
     const isAllowed = isPinchAllowed(this);
     if (!isAllowed) return;
 
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
     event.stopPropagation();
 
     handlePinchZoom(this, event);
@@ -430,7 +438,9 @@ export class ZoomPanPinch {
       const isAllowed = isPanningAllowed(this);
       if (!isAllowed) return;
 
-      event.preventDefault();
+      if (event.cancelable) {
+        event.preventDefault();
+      }
       event.stopPropagation();
 
       const touch = event.touches[0];

--- a/src/core/wheel/wheel.logic.ts
+++ b/src/core/wheel/wheel.logic.ts
@@ -53,7 +53,9 @@ export const handleWheelZoom = (
     throw new Error("Component not mounted");
   }
 
-  event.preventDefault();
+  if (event.cancelable) {
+    event.preventDefault();
+  }
   event.stopPropagation();
 
   const delta = getDelta(event, null);


### PR DESCRIPTION
Fixes #538

Added event.cancelable checks before calling preventDefault() on touch and wheel events to prevent console warnings when handling non-cancelable events.