### PR TITLE
fix(stories): stop pin click propagation in image annotations example

### DIFF
--- a/src/stories/examples/image-annotations/example.tsx
+++ b/src/stories/examples/image-annotations/example.tsx
@@ -839,6 +839,7 @@ function AnnotationCanvas(props: {
   const handlePinClick = useCallback(
     (e: React.MouseEvent) => {
       if (placeMode !== "pin") return;
+      e.stopPropagation();
       const pt = clientToContent(
         e.clientX,
         e.clientY,


### PR DESCRIPTION
## Summary
- Fixes pin placement behavior in the `image-annotations` story.
- Adds `e.stopPropagation()` in `handlePinClick` to prevent click bubbling to the parent canvas handler.
- Prevents unintended state reset (`setDraft(null)`) while placing pins.

## Root cause
The click event used to place a pin was bubbling to the parent canvas click handler, which clears selection and draft state.

Fixes #559